### PR TITLE
Make "Hide Search Matches" work; Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,11 @@ Start with the installation of Python and Node modules:
 Compile frontend changes:
    make frontend
 
-Build, import from package, test, render the docs and open in browser:
+Build, import from package, test, render the repo docs and open in browser:
    make install test-import docs
 
+See grunt help for more grunt commands:
+   grunt --help
 """)
 endef
 export PRINT_HELP_PYSCRIPT

--- a/sphinx_typo3_theme/searchbox.html
+++ b/sphinx_typo3_theme/searchbox.html
@@ -1,5 +1,5 @@
 {%- if builder != "singlehtml" %}
-<div class="toc-search" role="search">
+<div id="searchbox" class="toc-search" role="search">
     <form id="search-form" action="{{ pathto('search') }}" autocomplete="off" method="get">
         <input class="form-control" type="text" name="q" placeholder="Search this project" aria-label="Search this project" id="searchinput" />
         <input type="hidden" name="check_keywords" value="yes" />


### PR DESCRIPTION
Solves #67 This is actually a functionality of the Sphinx Javascript tools. They just need `<div id="searchbox" ...>` to work.

The Sphinx scripts will add a "Hide Search Matches" link for pages that have a "?highlight=" Parameter in the URL:
![image](https://user-images.githubusercontent.com/307057/78812707-1fade200-79cc-11ea-8898-b2d10c271bb0.png)
