### PR TITLE
[TASK] Replace `git://github.com/` with `git@github.com:`

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ you through the process.
 
    .. code-block:: console
 
-       $ git clone git://github.com/typo3-documentation/sphinx_typo3_theme
+       $ git clone git@github.com:typo3-documentation/sphinx_typo3_theme
 
    Or download the `tarball`_:
 


### PR DESCRIPTION
See TYPO3-Documentation/T3DocTeam#163 for details.