### PR TITLE
[FEATURE] Add a link to the TYPO3 Code of Conduct to the footer

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+This project uses the
+[TYPO3 Code of Conduct](https://typo3.org/community/values/code-of-conduct).
+
+When you contribute to this project or interact with community members,
+you agree to adhere to this code of conduct.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,0 @@
-# Code of Conduct
-
-This project uses the
-[TYPO3 Code of Conduct](https://typo3.org/community/values/code-of-conduct).
-
-When you contribute to this project or interact with community members,
-you agree to adhere to this code of conduct.

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,9 @@
+===============
+Code of Conduct
+===============
+
+This project uses the `TYPO3 Code of Conduct
+<https://typo3.org/community/values/code-of-conduct>`_.
+
+When you contribute to this project or interact with community members,
+you agree to adhere to this code of conduct.

--- a/sphinx_typo3_theme/footer.html
+++ b/sphinx_typo3_theme/footer.html
@@ -68,6 +68,7 @@
                     <ul class="footer-meta-navigation">
                         <li><a href="https://typo3.org/legal-notice" rel="nofollow" target="_blank" title="Legal Notice">Legal Notice</a></li>
                         <li><a href="https://typo3.org/privacy-policy" rel="nofollow" target="_blank" title="Privacy Policy">Privacy Policy</a></li>
+                        <li><a href="https://typo3.org/community/values/code-of-conduct" target="_blank">Code of Conduct</a></li>
                     </ul>
                     {%- endif %}
                 </div>


### PR DESCRIPTION
The TYPO3 Code of conduct should be easily accessible from all
official TYPO3-related sites so that people in distress due to
a possible incident do not need to invest much time trying to
find out how to get help.