### PR TITLE
Improve handling of style variable in template.

### DIFF
--- a/sphinx_typo3_theme/layout.html
+++ b/sphinx_typo3_theme/layout.html
@@ -54,7 +54,13 @@
 {%- endfor %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/fontawesome.css', 1) }}" />
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/webfonts.css', 1) }}" />
-    <link rel="stylesheet" type="text/css" href="{{ pathto('_static/' + style, 1) }}" />
+    {# Sphinx >= 5.1 uses a styles list instead, only define that ourselves if not already existing #}
+    {%- if styles is not defined %}
+      {% set styles = [style] %}
+    {%- endif %}
+    {%- for style in styles %}
+      <link rel="stylesheet" type="text/css" href="{{ pathto('_static/' + style, 1) }}" />
+    {%- endfor %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/css/codeblock.css', 1) }}" />
 <!-- linktags -->
 {%- block linktags %}


### PR DESCRIPTION
The `style` variable is missing in Sphinx 7. Instead, it now uses a list of `styles` [1]. This new list was already added in Sphinx 5.1. It looks like the `style` was only removed in Sphinx 7, though.

This commit updates the `layout.html` template to define the styles variable if it is missing. This makes the change compatible with both Sphinx <5.1 and versions later than that.

This change is enough to make our documentation buildable with Sphinx 7 when using this theme.

[1] https://www.sphinx-doc.org/en/master/development/templating.html#styles