### PR TITLE
[TASK] Make navigation sticky on the left side

### DIFF
--- a/sass/_component_page.scss
+++ b/sass/_component_page.scss
@@ -52,6 +52,12 @@
     margin-right: -($grid-gutter-width / 2);
     padding: ($grid-gutter-width / 2);
     border-bottom: 1px solid rgba(0, 0, 0, .15);
+
+    nav {
+        position: sticky;
+        top: 2rem;
+    }
+
     @include media-breakpoint-up(lg) {
         padding: ($spacer * 2) 0;
         flex-shrink: 0;


### PR DESCRIPTION
To have a better overview this change adds a sticky position to the navigation on the left.
After that the navigation is always available, especially on large pages, like:

<img width="1042" alt="grafik" src="https://github.com/user-attachments/assets/a72bdea9-6f63-4f2a-a759-43462ea900a3">
